### PR TITLE
Sleeping world age spawning nearby player

### DIFF
--- a/BP/scripts/main.js
+++ b/BP/scripts/main.js
@@ -1,7 +1,7 @@
 import { world, system, EntityTypes, Entity, Player, ItemStack } from "@minecraft/server";
 import { ActionFormData, ModalFormData } from "@minecraft/server-ui";
 import { getCodex, markCodex, showCodexBook, saveCodex } from "./mb_codex.js";
-import { initializeDayTracking, getCurrentDay, getInfectionMessage, checkDailyEventsForAllPlayers, getDayDisplayInfo } from "./mb_dayTracker.js";
+import { initializeDayTracking, getCurrentDay, getInfectionMessage, checkDailyEventsForAllPlayers } from "./mb_dayTracker.js";
 
 // NOTE: Debug and testing features have been commented out for playability
 // To re-enable testing features, uncomment the following sections:
@@ -3005,7 +3005,7 @@ world.beforeEvents.itemUse.subscribe((event) => {
                     player.addEffect("minecraft:blindness", 60, { amplifier: 0 }); // 3 seconds
                 }
             } catch {}
-            showCodexBook(player, { playerInfection, curedPlayers, formatTicksDuration, formatMillisDuration, HITS_TO_INFECT, bearHitCount, maxSnowLevels, checkVariantUnlock, getCurrentDay, getDayDisplayInfo });
+            showCodexBook(player, { playerInfection, curedPlayers, formatTicksDuration, formatMillisDuration, HITS_TO_INFECT, bearHitCount, maxSnowLevels, checkVariantUnlock, getCurrentDay });
         });
         return;
     }

--- a/BP/scripts/mb_codex.js
+++ b/BP/scripts/mb_codex.js
@@ -139,7 +139,7 @@ export function updateSymptomMeta(player, effectId, durationTicks, amp, source, 
 }
 
 export function showCodexBook(player, context) {
-    const { playerInfection, curedPlayers, formatTicksDuration, formatMillisDuration, HITS_TO_INFECT, bearHitCount, maxSnowLevels, checkVariantUnlock, getCurrentDay, getDayDisplayInfo } = context;
+    const { playerInfection, curedPlayers, formatTicksDuration, formatMillisDuration, HITS_TO_INFECT, bearHitCount, maxSnowLevels, checkVariantUnlock, getCurrentDay } = context;
     
     // Check for variant unlocks when opening the codex
     if (checkVariantUnlock) {
@@ -160,8 +160,7 @@ export function showCodexBook(player, context) {
         
         // Add current day
         const currentDay = getCurrentDay ? getCurrentDay() : 0;
-        const display = typeof getDayDisplayInfo === 'function' ? getDayDisplayInfo(currentDay) : { color: '§f', symbols: '' };
-        summary.push(`${display.color}${display.symbols} Current Day: ${currentDay}`);
+        summary.push(`§6Current Day: §f${currentDay}`);
         
         // Health status logic
         if (hasInfection) {

--- a/BP/scripts/mb_dayTracker.js
+++ b/BP/scripts/mb_dayTracker.js
@@ -50,7 +50,7 @@ let dayCycleLoopId = null;
  * @param {number} day The current day
  * @returns {object} Object with color and symbols
  */
-export function getDayDisplayInfo(day) {
+function getDayDisplayInfo(day) {
     if (day < 2) {
         // Days 0-1: Green, no hazard symbols
         return { color: "§a", symbols: "" };
@@ -528,9 +528,6 @@ export async function mbiHandleMilestoneDay(day) {
                     world.sendMessage(`§8[MBI] §4The infection has increased to new heights...`);
                     break;
             }
-
-            // Spawn pulse to guarantee milestone visibility even if world age lags due to sleeping
-            runMilestoneSpawnPulse(day);
         } catch (error) {
             console.warn("[ERROR] in mbiHandleMilestoneDay:", error);
             if (error && error.stack) {
@@ -538,121 +535,6 @@ export async function mbiHandleMilestoneDay(day) {
             }
         }
     }, 80); // 4 seconds delay
-}
-
-// --- Milestone spawn pulse ---
-const MILESTONE_PULSE_FLAG_PREFIX = "mbi_milestone_pulse_"; // e.g. mbi_milestone_pulse_2
-
-function hasMilestonePulseRun(day) {
-    try {
-        return !!world.getDynamicProperty(MILESTONE_PULSE_FLAG_PREFIX + String(day));
-    } catch {}
-    return false;
-}
-
-function setMilestonePulseRun(day) {
-    try {
-        world.setDynamicProperty(MILESTONE_PULSE_FLAG_PREFIX + String(day), true);
-    } catch {}
-}
-
-function pickSpawnTypeForDay(day) {
-    // Use base identifiers to avoid cross-module constants
-    if (day >= 13) {
-        // Prefer day 13 variants where available
-        return ["mb:mb_day13", "mb:infected_day13", "mb:buff_mb_day13"];
-    }
-    if (day >= 8) {
-        return ["mb:mb_day8", "mb:infected_day8", "mb:buff_mb"]; // buff_mb_day13 not yet
-    }
-    if (day >= 4) {
-        return ["mb:mb_day4", "mb:infected"]; // no buff yet
-    }
-    // Day 2
-    return ["mb:mb"]; // tiny bears only
-}
-
-function runMilestoneSpawnPulse(day) {
-    // Only once per world per milestone
-    if (hasMilestonePulseRun(day)) {
-        return;
-    }
-
-    const types = pickSpawnTypeForDay(day);
-    if (!types || types.length === 0) {
-        setMilestonePulseRun(day);
-        return;
-    }
-
-    // For each player, spawn a small, capped number of entities nearby
-    const players = world.getAllPlayers();
-    for (const player of players) {
-        try {
-            if (!player || !player.isValid()) continue;
-
-            const base = player.location;
-            const dim = player.dimension;
-            // Spawn up to 2 entities per player for lower spam
-            const spawnsPerPlayer = Math.min(2, types.length);
-            for (let i = 0; i < spawnsPerPlayer; i++) {
-                const typeId = types[i % types.length];
-                // Offset around player (no brightness/biome restrictions; they spawn everywhere)
-                const angle = Math.random() * Math.PI * 2;
-                const isBuff = typeId === "mb:buff_mb" || typeId === "mb:buff_mb_day13";
-                const radius = isBuff ? (30 + Math.floor(Math.random() * 21)) : (8 + Math.floor(Math.random() * 7));
-                const targetX = base.x + Math.cos(angle) * radius;
-                const targetZ = base.z + Math.sin(angle) * radius;
-
-                let spawnLoc = { x: targetX, y: base.y, z: targetZ };
-
-                // Try to place on surface for buff (far and surface only). For others, prefer surface when available.
-                const surface = findSurfaceLocation(dim, targetX, base.y, targetZ);
-                if (surface && (isBuff || true)) {
-                    spawnLoc = surface;
-                } else if (isBuff) {
-                    // If we couldn't find surface for buff, skip to avoid cave spawns
-                    continue;
-                }
-
-                try {
-                    dim.spawnEntity(typeId, spawnLoc);
-                } catch {}
-            }
-        } catch {}
-    }
-
-    setMilestonePulseRun(day);
-}
-
-// Attempt to find a surface location near x,z by scanning downward from above the player
-function findSurfaceLocation(dimension, x, baseY, z) {
-    try {
-        // Start above the player and scan downward for first solid-with-air-above
-        const yStart = Math.min(255, Math.floor(baseY) + 40);
-        for (let y = yStart; y >= 1; y--) {
-            const below = dimension.getBlock({ x: Math.floor(x), y: y - 1, z: Math.floor(z) });
-            const at = dimension.getBlock({ x: Math.floor(x), y: y, z: Math.floor(z) });
-            if (!below || !at) continue;
-
-            const belowId = safeBlockId(below);
-            const atId = safeBlockId(at);
-
-            const belowSolid = belowId && belowId !== "minecraft:air" && !isLiquid(belowId);
-            const atAir = atId === "minecraft:air";
-            if (belowSolid && atAir) {
-                return { x, y, z };
-            }
-        }
-    } catch {}
-    return null;
-}
-
-function safeBlockId(block) {
-    try { return block.typeId; } catch { return undefined; }
-}
-
-function isLiquid(typeId) {
-    return typeId === "minecraft:water" || typeId === "minecraft:flowing_water" || typeId === "minecraft:lava" || typeId === "minecraft:flowing_lava";
 }
 
 /**

--- a/BP/spawn_rules/buff_mb - day 13.sr.json
+++ b/BP/spawn_rules/buff_mb - day 13.sr.json
@@ -46,10 +46,10 @@
 					"coarse_dirt",
 					"mycelium"
 				],
-                "minecraft:world_age_filter": {
-                    "min": 15000,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 15600,
+					"max": 999999
+				}
 			},
 			{
 				"minecraft:spawns_on_surface": {},
@@ -240,10 +240,10 @@
 						}
 					]
 				},
-                "minecraft:world_age_filter": {
-                    "min": 15000,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 15600,
+					"max": 999999
+				}
 			}
 		]
 	}

--- a/BP/spawn_rules/buff_mb.sr.json
+++ b/BP/spawn_rules/buff_mb.sr.json
@@ -46,10 +46,10 @@
 					"coarse_dirt",
 					"mycelium"
 				],
-                "minecraft:world_age_filter": {
-                    "min": 9000,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 9600,
+					"max": 999999
+				}
 			},
 			{
 				"minecraft:spawns_on_surface": {},
@@ -240,10 +240,10 @@
 						}
 					]
 				},
-                "minecraft:world_age_filter": {
-                    "min": 9000,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 9600,
+					"max": 999999
+				}
 			}
 		]
 	}

--- a/BP/spawn_rules/infected - day 13.sr.json
+++ b/BP/spawn_rules/infected - day 13.sr.json
@@ -46,10 +46,10 @@
 					"coarse_dirt",
 					"mycelium"
 				],
-                "minecraft:world_age_filter": {
-                    "min": 15000,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 15600,
+					"max": 999999
+				}
 			},
 			{
 				"minecraft:spawns_on_surface": {},
@@ -280,10 +280,10 @@
 						}
 					]
 				},
-                "minecraft:world_age_filter": {
-                    "min": 15000,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 15600,
+					"max": 999999
+				}
 			}
 		]
 	}

--- a/BP/spawn_rules/infected - day 8.sr.json
+++ b/BP/spawn_rules/infected - day 8.sr.json
@@ -46,10 +46,10 @@
 					"coarse_dirt",
 					"mycelium"
 				],
-                "minecraft:world_age_filter": {
-                    "min": 9000,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 9600,
+					"max": 999999
+				}
 			},
 			{
 				"minecraft:spawns_on_surface": {},
@@ -280,10 +280,10 @@
 						}
 					]
 				},
-                "minecraft:world_age_filter": {
-                    "min": 9000,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 9600,
+					"max": 999999
+				}
 			}
 		]
 	}

--- a/BP/spawn_rules/infected.sr.json
+++ b/BP/spawn_rules/infected.sr.json
@@ -46,10 +46,10 @@
 					"coarse_dirt",
 					"mycelium"
 				],
-                "minecraft:world_age_filter": {
-                    "min": 4200,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 4800,
+					"max": 999999
+				}
 			},
 			{
 				"minecraft:spawns_on_surface": {},
@@ -220,10 +220,10 @@
 						}
 					]
 				},
-                "minecraft:world_age_filter": {
-                    "min": 4200,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 4800,
+					"max": 999999
+				}
 			}
 		]
 	}

--- a/BP/spawn_rules/infected_cow.sr.json
+++ b/BP/spawn_rules/infected_cow.sr.json
@@ -27,7 +27,7 @@
 					"value": "animal"
 				},
 				"minecraft:world_age_filter": { 
-					"min": 15000,
+					"min": 15600,
 					"max": 1000000
 				}
 			}

--- a/BP/spawn_rules/infected_pig.sr.json
+++ b/BP/spawn_rules/infected_pig.sr.json
@@ -28,7 +28,7 @@
 					]
 				},
 				"minecraft:world_age_filter": { 
-					"min": 15000,
+					"min": 15600,
 					"max": 1000000
 				}
 			}

--- a/BP/spawn_rules/mb - day 13.sr.json
+++ b/BP/spawn_rules/mb - day 13.sr.json
@@ -46,10 +46,10 @@
 					"coarse_dirt",
 					"mycelium"
 				],
-                "minecraft:world_age_filter": {
-                    "min": 15000,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 15600,
+					"max": 999999
+				}
 			},
 			{
 				"minecraft:spawns_on_surface": {},
@@ -280,10 +280,10 @@
 						}
 					]
 				},
-                "minecraft:world_age_filter": {
-                    "min": 15000,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 15600,
+					"max": 999999
+				}
 			}
 		]
 	}

--- a/BP/spawn_rules/mb - day 4.sr.json
+++ b/BP/spawn_rules/mb - day 4.sr.json
@@ -46,10 +46,10 @@
 					"coarse_dirt",
 					"mycelium"
 				],
-                "minecraft:world_age_filter": {
-                    "min": 4200,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 4800,
+					"max": 999999
+				}
 			},
 			{
 				"minecraft:spawns_on_surface": {},
@@ -280,10 +280,10 @@
 						}
 					]
 				},
-                "minecraft:world_age_filter": {
-                    "min": 4200,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 4800,
+					"max": 999999
+				}
 			}
 		]
 	}

--- a/BP/spawn_rules/mb - day 8.sr.json
+++ b/BP/spawn_rules/mb - day 8.sr.json
@@ -46,10 +46,10 @@
 					"coarse_dirt",
 					"mycelium"
 				],
-                "minecraft:world_age_filter": {
-                    "min": 9000,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 9600,
+					"max": 999999
+				}
 			},
 			{
 				"minecraft:spawns_on_surface": {},
@@ -280,10 +280,10 @@
 						}
 					]
 				},
-                "minecraft:world_age_filter": {
-                    "min": 9000,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 9600,
+					"max": 999999
+				}
 			}
 		]
 	}

--- a/BP/spawn_rules/mb.sr.json
+++ b/BP/spawn_rules/mb.sr.json
@@ -46,10 +46,10 @@
 					"coarse_dirt",
 					"mycelium"
 				],
-                "minecraft:world_age_filter": {
-                    "min": 1800,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 2400,
+					"max": 999999
+				}
 			},
 			{
 				"minecraft:spawns_on_surface": {},
@@ -280,10 +280,10 @@
 						}
 					]
 				},
-                "minecraft:world_age_filter": {
-                    "min": 1800,
-                    "max": 999999
-                }
+				"minecraft:world_age_filter": {
+					"min": 2400,
+					"max": 999999
+				}
 			}
 		]
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Gameplay Balance
  - Delayed spawning by increasing the minimum world age across multiple entities and day-specific rules, resulting in later onset of infected and buff spawns.
  - Removed milestone “spawn pulse” behavior; milestone days no longer trigger extra spawn bursts.

- UI
  - Codex now shows a simplified day label (“Current Day: X”) for clearer, consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->