### PR TITLE
Add short white dust particle for infection dust breath

### DIFF
--- a/BP/scripts/mb_infectionAudio.js
+++ b/BP/scripts/mb_infectionAudio.js
@@ -5,6 +5,8 @@
 
 import { world, system } from "@minecraft/server";
 
+const COUGH_DUST_PARTICLE = "mb:white_dust_particle_short";
+
 const COUGH_SOUND_MINOR = "mb.infection_cough_minor";
 const COUGH_SOUND_MAJOR = "mb.infection_cough_major";
 const HICCUP_SOUND = "mb.dust_eat_hiccup";
@@ -161,7 +163,7 @@ export function tickInfectionCoughAndBreath(sourcePlayer, infectionState, ctx) {
             const dim = sourcePlayer.dimension;
             const l = sourcePlayer.location;
             if (dim && l) {
-                dim.spawnParticle("mb:white_dust_particle", { x: l.x, y: l.y + 1.2, z: l.z });
+                dim.spawnParticle(COUGH_DUST_PARTICLE, { x: l.x, y: l.y + 1.2, z: l.z });
             }
         } catch { /* ignore */ }
         const breathVol = BASE_DEFINITION_ATTENUATION * MAJOR_VOLUME_MULT * (0.36 + Math.random() * 0.12);

--- a/RP/particles/white_dust_particle_short.particle.json
+++ b/RP/particles/white_dust_particle_short.particle.json
@@ -1,0 +1,77 @@
+{
+	"format_version": "1.10.0",
+	"particle_effect": {
+		"description": {
+			"identifier": "mb:white_dust_particle_short",
+			"basic_render_parameters": {
+				"material": "particles_blend",
+				"texture": "textures/particle/white_dust_particle"
+			}
+		},
+		"components": {
+			"minecraft:emitter_local_space": {
+				"position": true,
+				"rotation": true
+			},
+			"minecraft:emitter_rate_steady": {
+				"spawn_rate": 14,
+				"max_particles": 28
+			},
+			"minecraft:emitter_shape_sphere": {
+				"radius": 0.35,
+				"direction": [
+					0,
+					-0.1,
+					0
+				]
+			},
+			"minecraft:particle_lifetime_expression": {
+				"max_lifetime": 0.42
+			},
+			"minecraft:particle_initial_spin": {
+				"rotation": "math.random(-180,180)",
+				"rotation_rate": 5
+			},
+			"minecraft:particle_initial_speed": 0.3,
+			"minecraft:particle_motion_dynamic": {
+				"rotation_acceleration": 5
+			},
+			"minecraft:particle_appearance_billboard": {
+				"size": [
+					0.5,
+					0.5
+				],
+				"facing_camera_mode": "lookat_xyz",
+				"uv": {
+					"texture_width": 16,
+					"texture_height": 16,
+					"uv": [
+						0,
+						0
+					],
+					"uv_size": [
+						16,
+						16
+					]
+				}
+			},
+			"minecraft:particle_appearance_lighting": {},
+			"minecraft:particle_appearance_tinting": {
+				"color": [
+					1,
+					1,
+					1,
+					1
+				]
+			},
+			"minecraft:emitter_lifetime_once": {
+				"active_time": 0.38
+			},
+			"minecraft:particle_motion_collision": {
+				"enabled": true,
+				"collision_radius": 0.5,
+				"collision_drag": 0.1
+			}
+		}
+	}
+}

--- a/docs/ai/CONTEXT_SUMMARY.md
+++ b/docs/ai/CONTEXT_SUMMARY.md
@@ -2,6 +2,11 @@
 
 ## Recent Changes (Latest Session)
 
+### Short white dust particle for infection breath (2026-03-28)
+- **`RP/particles/white_dust_particle_short.particle.json`**: New effect `mb:white_dust_particle_short` — same texture/material as `mb:white_dust_particle`, tuned for **brief** emission (`emitter_lifetime_once` ~0.38s, particle `max_lifetime` ~0.42s, smaller burst vs the 6s original).
+- **`BP/scripts/mb_infectionAudio.js`**: Rare **dust breath** (infection cough/breath path) spawns **`mb:white_dust_particle_short`** instead of the long vanilla-style puff. Other systems (death dust, storms, conversion VFX) still use **`mb:white_dust_particle`**.
+- **`docs/development/systems/INFECTION_SYSTEM.md`**: Dust breath line updated to the short identifier.
+
 ### Infection cough audio vs settings / creative (2026-03-22)
 - **`mb_infectionAudio.js`**: Emitter tier **Off** — **you** still get quiet cough/hiccup/sigh; others hear nothing. **Dust breath**: particle + **`mb.infection_cough_major`** (random variant from definitions), softer gain than a normal major cough; no separate emitter gate on the breath roll. **`main.js`**: Cough/breath in **creative** too (not **spectator**). **`mb_codex.js`**: Symptoms copy for Off / Low / High; **Basic → Your Goal** infection-time line kept **short**.
 

--- a/docs/development/systems/INFECTION_SYSTEM.md
+++ b/docs/development/systems/INFECTION_SYSTEM.md
@@ -294,7 +294,7 @@ flowchart TD
 - **Settings** (Powdery Journal → Settings): `infectionCueEmitterVolume` and `infectionCueHearOthersVolume` (Off / Low / High). Emitter **Off** suppresses cough, hiccup, and cure sigh for everyone; **Hear others** only affects other players’ infection noises.
 - **Coughs**: Random interval during minor/major infection (major more frequent and louder). **Storm** or **corrupted ground** increases chance (synergy).
 - **Powder hiccup**: Plays when consuming `mb:snow` (pitch ~1.25).
-- **Dust breath**: Very rare `mb:white_dust_particle` at the player’s head (no extra sound).
+- **Dust breath**: Very rare `mb:white_dust_particle_short` at the player’s head (short-lived variant of white dust) plus a softer **`mb.infection_cough_major`** play (RP picks a random file).
 - **Cure sigh**: Minor and major cure paths play `mb.cure_sigh_relief_minor` / `mb.cure_sigh_relief_major`.
 - **Sounds** (definitions in `RP/sounds/sound_definitions.json`, assets under `sounds/infection_cough/`, `dust_eat_hiccup/`, `cure_sigh_relief/`): per-file volumes **0.68** (cough/hiccup) and **0.34** (cure sighs), with script-side tier multipliers.
 - **Codex**: `symptomsUnlocks.infectionBodySoundsUnlocked` unlocks **Symptoms → Body sounds (infection)** and an **Infection** book line under mechanics.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "workspace",
+  "name": "maplebear-takeover",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "workspace",
+      "name": "maplebear-takeover",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **`mb:white_dust_particle_short`**, a duplicate of the existing white dust particle with a **much shorter** emitter and particle lifetime, and uses it for the rare **infection dust breath** puff in `mb_infectionAudio.js` instead of **`mb:white_dust_particle`**.

## Details

- **New**: `RP/particles/white_dust_particle_short.particle.json` — same texture as `white_dust_particle`; tuned for a quick burst (~0.38s active emitter, ~0.42s max particle life) vs the original 6s lifetime.
- **Script**: `BP/scripts/mb_infectionAudio.js` — dust breath path spawns the short identifier via a `COUGH_DUST_PARTICLE` constant.
- **Docs**: `INFECTION_SYSTEM.md` (dust breath line + accurate note about major cough sound), `docs/ai/CONTEXT_SUMMARY.md`.
- **Chore**: `package-lock.json` top-level `name` aligned with `package.json` (`maplebear-takeover`).

Death dust, storms, conversion, and other `spawnParticle("mb:white_dust_particle", …)` call sites are unchanged.

## Validation

- `npm run validate` — pass
- `npm run lint` — pass (warnings only, pre-existing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17af6653-d999-4a1a-9a2a-e96d90d171e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17af6653-d999-4a1a-9a2a-e96d90d171e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refined infection dust breath particle effect with optimized shorter duration and improved visual presentation during cough symptoms
  * Enhanced infection audio with new cough sound integration

* **Documentation**
  * Updated infection system documentation with revised dust breath particle specifications and audio behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->